### PR TITLE
feat(README): update project links and copyright info

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Djarvur
+Copyright (c) 2019 yxxhero
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,8 @@
-# go-lsmod image:https://godoc.org/github.com/Djarvur/go-lsmod?status.svg["GoDoc",link="http://godoc.org/github.com/Djarvur/go-lsmod"] image:https://travis-ci.org/Djarvur/go-lsmod.svg["Build Status",link="https://travis-ci.org/Djarvur/go-lsmod"] image:https://coveralls.io/repos/Djarvur/go-lsmod/badge.svg?branch=master&service=github["Coverage Status",link="https://coveralls.io/github/Djarvur/go-lsmod?branch=master"]
+# go-lsmod image:https://godoc.org/github.com/yxxhero/go-lsmod?status.svg["GoDoc",link="http://godoc.org/github.com/yxxhero/go-lsmod"] image:https://travis-ci.org/yxxhero/go-lsmod.svg["Build Status",link="https://travis-ci.org/yxxhero/go-lsmod"] image:https://coveralls.io/repos/yxxhero/go-lsmod/badge.svg?branch=master&service=github["Coverage Status",link="https://coveralls.io/github/yxxhero/go-lsmod?branch=master"]
 
 simple `/proc/modules` parser
 
 *Linux only!*
+
+
+Thanks for https://github.com/Djarvur/go-lsmod

--- a/cmd/lsmod/main.go
+++ b/cmd/lsmod/main.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	lsmod "github.com/Djarvur/go-lsmod"
+	lsmod "github.com/yxxhero/go-lsmod"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
-module github.com/Djarvur/go-lsmod
+module github.com/yxxhero/go-lsmod
+
+go 1.23.1
 
 require github.com/pkg/errors v0.8.1

--- a/lsmod_test.go
+++ b/lsmod_test.go
@@ -3,7 +3,7 @@ package lsmod_test
 import (
 	"testing"
 
-	"github.com/Djarvur/go-lsmod"
+	"github.com/yxxhero/go-lsmod"
 )
 
 func TestLsMod(t *testing.T) {


### PR DESCRIPTION
This pull request includes several changes to update the repository ownership and references from `Djarvur` to `yxxhero`. The most important changes include modifications to the `LICENSE`, `README.adoc`, `cmd/lsmod/main.go`, `go.mod`, and `lsmod_test.go` files.

Repository ownership and reference updates:

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Updated the copyright holder from `Djarvur` to `yxxhero`.
* [`README.adoc`](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L1-R8): Changed repository references from `Djarvur` to `yxxhero` in badges and links.
* [`cmd/lsmod/main.go`](diffhunk://#diff-ccf4f758a3309c38a0ea318bf057976b4725b9b40b581b8e44a49972835272cdL9-R9): Updated the import path from `github.com/Djarvur/go-lsmod` to `github.com/yxxhero/go-lsmod`.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L1-R3): Changed the module path from `github.com/Djarvur/go-lsmod` to `github.com/yxxhero/go-lsmod` and specified `go 1.23.1`.
* [`lsmod_test.go`](diffhunk://#diff-d7fdb125d5c3b1697a04c1e98ae6bdc84653aaf231429ce903703db49aeaf91fL6-R6): Updated the import path in tests from `github.com/Djarvur/go-lsmod` to `github.com/yxxhero/go-lsmod`.