### PR TITLE
feat: refactor modInfo struct to support multiple tained flags

### DIFF
--- a/modinfo.go
+++ b/modinfo.go
@@ -6,6 +6,6 @@ type ModInfo struct {
 	Mem       uint64
 	Instances uint64
 	Offset    uint64
-	Tained    modTained
+	Taineds   []modTained
 	State     modState
 }

--- a/modtained.go
+++ b/modtained.go
@@ -1,6 +1,9 @@
 package lsmod
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type modTained uint32
 
@@ -27,90 +30,54 @@ const (
 	TainedT    modTained = 131072 // (T): The kernel was built with the struct randomization plugin.
 )
 
-func parseTained(t string) (modTained, error) { // nolint: gocyclo
-	switch t {
-	case "(P)":
-		return TainedP, nil
-	case "(F)":
-		return TainedF, nil
-	case "(S)":
-		return TainedS, nil
-	case "(R)":
-		return TainedR, nil
-	case "(M)":
-		return TainedM, nil
-	case "(B)":
-		return TainedB, nil
-	case "(U)":
-		return TainedU, nil
-	case "(D)":
-		return TainedD, nil
-	case "(A)":
-		return TainedA, nil
-	case "(W)":
-		return TainedW, nil
-	case "(C)":
-		return TainedC, nil
-	case "(I)":
-		return TainedI, nil
-	case "(O)":
-		return TainedO, nil
-	case "(E)":
-		return TainedE, nil
-	case "(L)":
-		return TainedL, nil
-	case "(K)":
-		return TainedK, nil
-	case "(X)":
-		return TainedX, nil
-	case "(T)":
-		return TainedT, nil
+func parseTained(tg string) ([]modTained, error) { // nolint: gocyclo
+	result := []modTained{}
+	tTrim := strings.Trim(tg, "()")
+	for i := 0; i < len(tTrim); i++ {
+		t := string(tTrim[i])
+		switch t {
+		case "P":
+			result = append(result, TainedP)
+		case "F":
+			result = append(result, TainedF)
+		case "S":
+			result = append(result, TainedS)
+		case "R":
+			result = append(result, TainedR)
+		case "M":
+			result = append(result, TainedM)
+		case "B":
+			result = append(result, TainedB)
+		case "U":
+			result = append(result, TainedU)
+		case "D":
+			result = append(result, TainedD)
+		case "A":
+			result = append(result, TainedA)
+		case "W":
+			result = append(result, TainedW)
+		case "C":
+			result = append(result, TainedC)
+		case "I":
+			result = append(result, TainedI)
+		case "O":
+			result = append(result, TainedO)
+		case "E":
+			result = append(result, TainedE)
+		case "L":
+			result = append(result, TainedL)
+		case "K":
+			result = append(result, TainedK)
+		case "X":
+			result = append(result, TainedX)
+		case "T":
+			result = append(result, TainedT)
+		}
 	}
 
-	return 0, fmt.Errorf("unknown tained flag %q", t)
-}
-
-func (t modTained) String() string { // nolint: gocyclo
-	switch t {
-	case TainedNone:
-		return "()"
-	case TainedP:
-		return "(P)"
-	case TainedF:
-		return "(F)"
-	case TainedS:
-		return "(S)"
-	case TainedR:
-		return "(R)"
-	case TainedM:
-		return "(M)"
-	case TainedB:
-		return "(B)"
-	case TainedU:
-		return "(U)"
-	case TainedD:
-		return "(D)"
-	case TainedA:
-		return "(A)"
-	case TainedW:
-		return "(W)"
-	case TainedC:
-		return "(C)"
-	case TainedI:
-		return "(I)"
-	case TainedO:
-		return "(O)"
-	case TainedE:
-		return "(E)"
-	case TainedL:
-		return "(L)"
-	case TainedK:
-		return "(K)"
-	case TainedX:
-		return "(X)"
-	case TainedT:
-		return "(T)"
+	if len(result) == 0 {
+		return nil, fmt.Errorf("unknown tained flag %q", tg)
 	}
 
-	panic(fmt.Errorf("unknown tained flag %d", t))
+	return result, nil
 }

--- a/parse.go
+++ b/parse.go
@@ -84,7 +84,7 @@ func parseInfo(fields []string) (info ModInfo, err error) {
 	}
 
 	if len(fields) == maxFieldsPerLine {
-		info.Tained, err = parseTained(fields[6])
+		info.Taineds, err = parseTained(fields[6])
 		if err != nil {
 			return info, errors.Wrap(err, "unknown tained (field 7)")
 		}

--- a/parse_test.go
+++ b/parse_test.go
@@ -31,7 +31,7 @@ var testData = map[string]ModInfo{
 		Mem:       3,
 		Instances: 1,
 		Offset:    3,
-		Tained:    TainedF,
+		Taineds:   []modTained{TainedF},
 		State:     StateLive,
 	},
 	"mod4": {


### PR DESCRIPTION
This pull request makes several changes to the `lsmod` package to support multiple tained states for modules. The most important changes include modifying the `ModInfo` struct to use a slice for tained states, updating the `parseTained` function to handle multiple tained states, and adjusting related parsing and test code accordingly.

### Struct and Parsing Changes:

* [`modinfo.go`](diffhunk://#diff-59a95c938ab38aec4007d3d26499bcc1d665693dc49c706e70c31aed9b65d18eL9-R9): Changed the `ModInfo` struct to use a slice `Taineds` instead of a single `Tained` value. (`[modinfo.goL9-R9](diffhunk://#diff-59a95c938ab38aec4007d3d26499bcc1d665693dc49c706e70c31aed9b65d18eL9-R9)`)
* [`modtained.go`](diffhunk://#diff-d114800a5accff4281b50646173fc0acd388c5b51db513867a40b50f8ab30a39L30-R82): Modified the `parseTained` function to return a slice of `modTained` values, handling multiple tained states in a single string. (`[modtained.goL30-R82](diffhunk://#diff-d114800a5accff4281b50646173fc0acd388c5b51db513867a40b50f8ab30a39L30-R82)`)

### Import and Error Handling:

* [`modtained.go`](diffhunk://#diff-d114800a5accff4281b50646173fc0acd388c5b51db513867a40b50f8ab30a39L3-R6): Added necessary imports (`fmt` and `strings`) for string manipulation and error handling. (`[modtained.goL3-R6](diffhunk://#diff-d114800a5accff4281b50646173fc0acd388c5b51db513867a40b50f8ab30a39L3-R6)`)

### Parsing Logic Update:

* [`parse.go`](diffhunk://#diff-1596bd8ceb74246828aacab827b39a33075c86baa627fbbeb7491bd31eef1169L87-R87): Updated the `parseInfo` function to use the new `parseTained` function and assign the result to `Taineds` in `ModInfo`. (`[parse.goL87-R87](diffhunk://#diff-1596bd8ceb74246828aacab827b39a33075c86baa627fbbeb7491bd31eef1169L87-R87)`)

### Test Adjustments:

* [`parse_test.go`](diffhunk://#diff-e93e273b358f8a3fef526e6a690d82f02dd3cf59d40fb654d350acdad8062991L34-R34): Adjusted test data to use the new `Taineds` slice in `ModInfo`. (`[parse_test.goL34-R34](diffhunk://#diff-e93e273b358f8a3fef526e6a690d82f02dd3cf59d40fb654d350acdad8062991L34-R34)`)